### PR TITLE
Update dependencies to LTS 14.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ matrix:
 
     # Cabal
     #- ghc: 8.8.1
-    #- ghc: 8.6.5
-    #- ghc: 8.4.4
-    #- ghc: 8.2.2
-    #- ghc: 8.0.2
+    - ghc: 8.6.5
+    - ghc: 8.4.4
+    - ghc: 8.2.2
+    - ghc: 8.0.2
     - ghc: 7.10.2
 
     # Stack

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,4 @@ install:
     fi
 
 script:
-  - |
-    if [ -z "$STACK_YAML" ]; then
-      cabal new-test --enable-tests
-    else
-      stack test --system-ghc
-    fi
-
   - curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh | sh -s -- hlint .

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,6 @@ matrix:
     - ghc: 8.6.5
       env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
 
-before_install:
-  - sudo add-apt-repository ppa:hvr/ghc -y
-  - sudo apt-get update -q
-  - sudo apt-get install cabal-install-3.0 -y
-
 install:
   - |
     if [ -z "$STACK_YAML" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,18 +13,15 @@ before_cache:
 
 matrix:
   include:
-    - env: CABALVER=1.22 GHCVER=7.10.2
-      compiler: ": #GHC 7.10.2"
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=8.0.2
-      compiler: ": #GHC 8.0.2"
-      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
-    - env: CABALVER=2.0 GHCVER=8.2.2
-      compiler: ": #GHC 8.2.2"
-      addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2], sources: [hvr-ghc]}}
-    - env: CABALVER=head GHCVER=head
-      compiler: ": #GHC head"
-      addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.8.1
+      compiler: ": #GHC 8.8.1"
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.8.1], sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.6.5
+      compiler: ": #GHC 8.6.5"
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.6.5], sources: [hvr-ghc]}}
+    - env: CABALVER=2.0 GHCVER=8.4.4
+      compiler: ": #GHC 8.4.4"
+      addons: {apt: {packages: [cabal-install-2.0,ghc-8.4.4], sources: [hvr-ghc]}}
 
   allow_failures:
     - env: CABALVER=head GHCVER=head

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,14 @@ install:
       ghc --version
       cabal --version
       cabal new-update
-      cabal new-build --enable-tests --enable-benchmarks
+      cabal new-build
     else
       # install stack
       curl -sSL https://get.haskellstack.org/ | sh
 
       # build project with stack
       stack --version
-      stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks
+      stack build --system-ghc --no-run-tests --no-run-benchmarks
     fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
     - ghc: 8.2.2
 
     # Stack
-    - ghc: 8.8.1
+    - ghc: 8.6.5
       env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,12 @@ matrix:
   include:
 
     # Cabal
-    # - ghc: 8.8.1
+    - ghc: 8.8.1
     - ghc: 8.6.5
     - ghc: 8.4.4
     - ghc: 8.2.2
     - ghc: 8.0.2
+    - ghc: 7.10.2
 
     # Stack
     - ghc: 8.6.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 git:
   depth: 5
 
-cabal: "2.4"
+cabal: 3.0
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,86 +1,52 @@
-# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
-language: c
-sudo: false
+language: haskell
+sudo: required
+
+git:
+  depth: 5
+
+cabal: "2.4"
 
 cache:
   directories:
-    - $HOME/.cabsnap
-    - $HOME/.cabal/packages
-
-before_cache:
-  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
-  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+    - "$HOME/.cabal/store"
+    - "$HOME/.stack"
+    - "$TRAVIS_BUILD_DIR/.stack-work"
 
 matrix:
   include:
-    - env: CABALVER=2.0 GHCVER=8.8.1
-      compiler: ": #GHC 8.8.1"
-      addons: {apt: {packages: [cabal-install-2.0,ghc-8.8.1], sources: [hvr-ghc]}}
-    - env: CABALVER=2.0 GHCVER=8.6.5
-      compiler: ": #GHC 8.6.5"
-      addons: {apt: {packages: [cabal-install-2.0,ghc-8.6.5], sources: [hvr-ghc]}}
-    - env: CABALVER=2.0 GHCVER=8.4.4
-      compiler: ": #GHC 8.4.4"
-      addons: {apt: {packages: [cabal-install-2.0,ghc-8.4.4], sources: [hvr-ghc]}}
 
-  allow_failures:
-    - env: CABALVER=head GHCVER=head
+    # Cabal
+    - ghc: 8.8.1
+    - ghc: 8.6.5
+    - ghc: 8.4.4
+    - ghc: 8.2.2
 
-before_install:
- - unset CC
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+    # Stack
+    - ghc: 8.8.1
+      env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
 
 install:
- - cabal --version
- - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
- - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
-   then
-     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
-          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
-   fi
- - travis_retry cabal update -v
- - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
- - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
- - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+  - |
+    if [ -z "$STACK_YAML" ]; then
+      ghc --version
+      cabal --version
+      cabal new-update
+      cabal new-build --enable-tests --enable-benchmarks
+    else
+      # install stack
+      curl -sSL https://get.haskellstack.org/ | sh
 
-# check whether current requested install-plan matches cached package-db snapshot
- - if diff -u $HOME/.cabsnap/installplan.txt installplan.txt;
-   then
-     echo "cabal build-cache HIT";
-     rm -rfv .ghc;
-     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
-     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
-   else
-     echo "cabal build-cache MISS";
-     rm -rf $HOME/.cabsnap;
-     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
-     cabal install --only-dependencies --enable-tests --enable-benchmarks;
-   fi
+      # build project with stack
+      stack --version
+      stack build --system-ghc --test --bench --no-run-tests --no-run-benchmarks
+    fi
 
-# snapshot package-db on cache miss
- - if [ ! -d $HOME/.cabsnap ];
-   then
-      echo "snapshotting package-db to build-cache";
-      mkdir $HOME/.cabsnap;
-      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
-      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
-   fi
-
-# Here starts the actual work to be performed for the package under test;
-# any command which exits with a non-zero exit code causes the build to fail.
 script:
- - if [ -f configure.ac ]; then autoreconf -i; fi
- - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
- - cabal build   # this builds all libraries and executables (including tests/benchmarks)
- - cabal test
- - cabal check
- - cabal haddock # tests that documentation can be generated
- - cabal sdist   # tests that a source-distribution can be generated
+  - |
+    if [ -z "$STACK_YAML" ]; then
+      cabal new-test --enable-tests
+    else
+      stack test --system-ghc
+    fi
 
-# Check that the resulting source distribution can be built & installed.
-# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
-# `cabal install --force-reinstalls dist/*-*.tar.gz`
- - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
-   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
-
-# EOF
+  - curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh | sh -s -- hlint .

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ matrix:
     - ghc: 8.6.5
       env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
 
+before_install:
+  - sudo add-apt-repository ppa:hvr/ghc -y
+  - sudo apt-get update -q
+  - sudo apt-get install cabal-install-3.0 -y
+
 install:
   - |
     if [ -z "$STACK_YAML" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,11 @@ matrix:
   include:
 
     # Cabal
-    - ghc: 8.8.1
+    # - ghc: 8.8.1
     - ghc: 8.6.5
     - ghc: 8.4.4
     - ghc: 8.2.2
+    - ghc: 8.0.2
 
     # Stack
     - ghc: 8.6.5
@@ -42,4 +43,4 @@ install:
     fi
 
 script:
-  - curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh | sh -s -- hlint .
+  - # curl -sSL https://raw.github.com/ndmitchell/neil/master/misc/travis.sh | sh -s -- hlint .

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ matrix:
 
     # Cabal
     #- ghc: 8.8.1
-    - ghc: 8.6.5
-    - ghc: 8.4.4
-    - ghc: 8.2.2
-    - ghc: 8.0.2
+    #- ghc: 8.6.5
+    #- ghc: 8.4.4
+    #- ghc: 8.2.2
+    #- ghc: 8.0.2
     - ghc: 7.10.2
 
     # Stack

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
   include:
 
     # Cabal
-    - ghc: 8.8.1
+    #- ghc: 8.8.1
     - ghc: 8.6.5
     - ghc: 8.4.4
     - ghc: 8.2.2

--- a/Data/Aeson/Diff/Generic/Instances.hs
+++ b/Data/Aeson/Diff/Generic/Instances.hs
@@ -173,7 +173,8 @@ deriving instance JsonPatch a => JsonPatch (Dual a)
 deriving instance (Typeable b, JsonPatch a) => JsonPatch (Const a b)
 deriving instance (Eq1 f, Eq1 g, FromJSON1 f, FromJSON1 g, Typeable f,
                    Typeable g, JsonPatch a, ToJSON1 f,
-                   ToJSON1 g, JsonPatch (f (g a)))
+                   ToJSON1 g, JsonPatch (f (g a)),
+                   Functor f)
                   => JsonPatch (Compose f g a)
 deriving instance (Typeable a, JsonPatch b) => JsonPatch (Tagged a b)
 

--- a/Data/Aeson/Diff/Generic/PathOptics.hs
+++ b/Data/Aeson/Diff/Generic/PathOptics.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DefaultSignatures #-}
 
 module Data.Aeson.Diff.Generic.PathOptics
   ( -- * type synonyms

--- a/Data/Aeson/Diff/Generic/PathOptics.hs
+++ b/Data/Aeson/Diff/Generic/PathOptics.hs
@@ -1,9 +1,8 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE CPP #-}
 
 module Data.Aeson.Diff.Generic.PathOptics
   ( -- * type synonyms
@@ -26,6 +25,13 @@ import Data.Aeson.Diff
 import Data.Aeson.Pointer
 import Data.Functor.Compose
 import Control.Lens
+
+-- base >= 4.8: `Monoid` class is exported via `Prelude`
+-- base < 4.11: re-exports `Monoid` class & common newtype wrappers
+-- base >= 4.11: doesn't reexport `Monoid` class anymore
+#if !(MIN_VERSION_base(4,11,0))
+import Data.Monoid
+#endif
 
 type PathTraversal s a = Traversal' (Path, s) (Path, a)
 type PathLens s a = Lens' (Path, s) (Path, a)

--- a/Data/Aeson/Diff/Generic/PathOptics.hs
+++ b/Data/Aeson/Diff/Generic/PathOptics.hs
@@ -21,12 +21,9 @@ module Data.Aeson.Diff.Generic.PathOptics
     _JustP)
 
 where
-import Prelude()
-import Prelude.Compat
 import Data.Aeson
 import Data.Aeson.Diff
 import Data.Aeson.Pointer
-import Data.Monoid
 import Data.Functor.Compose
 import Control.Lens
 

--- a/Data/Aeson/Diff/Generic/TH.hs
+++ b/Data/Aeson/Diff/Generic/TH.hs
@@ -15,7 +15,7 @@ import Language.Haskell.TH
 import Language.Haskell.TH.Datatype
 import Data.List
 import Data.Aeson.Diff.Generic.Types
-import Text.Read.Compat
+import Text.Read
 import qualified Data.Text as T
 import Control.Monad
 import Data.Maybe

--- a/aeson-diff-generic.cabal
+++ b/aeson-diff-generic.cabal
@@ -11,10 +11,7 @@ Maintainer:	Kristof Bastiaensen
 Bug-Reports: 	https://github.com/kuribas/aeson-diff-generic/issues
 Build-type:	Simple
 Cabal-version:	>=1.8
-Tested-With:    GHC == 7.10.2
-                GHC == 8.0.2
-                GHC == 8.2.2
-                GHC == 8.6.5
+Tested-With:    GHC ==8.4.4 || ==8.6.5 || ==8.8.1
 Description:	Apply a json-patch directly to a haskell datatype.  It extends the capabilities of the aeson-diff packages, and includes template haskell functions for automatically deriving the right instances.
 
 extra-source-files: .travis.yml

--- a/aeson-diff-generic.cabal
+++ b/aeson-diff-generic.cabal
@@ -16,7 +16,6 @@ Tested-With:    GHC == 7.10.2
               , GHC == 8.2.2
               , GHC == 8.4.4
               , GHC == 8.6.5
-              , GHC == 8.8.1
 Description:	Apply a json-patch directly to a haskell datatype.  It extends the capabilities of the aeson-diff packages, and includes template haskell functions for automatically deriving the right instances.
 
 extra-source-files: .travis.yml

--- a/aeson-diff-generic.cabal
+++ b/aeson-diff-generic.cabal
@@ -28,7 +28,9 @@ Source-repository head
   location:	https://github.com/kuribas/aeson-diff-generic
 
 Library
-  Ghc-options: -Wall -Wcompat
+  Ghc-options: -Wall
+  if impl(ghc >= 8.0)
+    Ghc-options: -Wcompat
   build-depends: base >= 4.5 && <= 5,
                  aeson >= 1.2.4.0 && < 1.5,
                  aeson-diff >= 1.1.0.0 && < 1.2,
@@ -51,11 +53,11 @@ Library
                  vector >= 0.8,
                  lens >= 4.16 && < 4.19
 
-
   if !impl(ghc >= 8.0)
-    -- `Data.Semigroup` and `Control.Monad.Fail` and `Control.Monad.IO.Class` are available in base only since GHC 8.0 / base 4.9
+    -- `Data.Semigroup`, `Control.Monad.Fail` and `Control.Monad.IO.Class`
+    -- are available in base only since GHC 8.0 / base 4.9
     build-depends:
-      semigroups >= 0.18.2 && < 0.19,
+      semigroups >= 0.18.2 && < 0.20,
       transformers >= 0.2.2.0,
       transformers-compat >= 0.3,
       fail == 4.9.*

--- a/aeson-diff-generic.cabal
+++ b/aeson-diff-generic.cabal
@@ -11,7 +11,12 @@ Maintainer:	Kristof Bastiaensen
 Bug-Reports: 	https://github.com/kuribas/aeson-diff-generic/issues
 Build-type:	Simple
 Cabal-version:	>=1.8
-Tested-With:    GHC ==8.4.4 || ==8.6.5 || ==8.8.1
+Tested-With:    GHC == 7.10.2
+              , GHC == 8.0.2
+              , GHC == 8.2.2
+              , GHC == 8.4.4
+              , GHC == 8.6.5
+              , GHC == 8.8.1
 Description:	Apply a json-patch directly to a haskell datatype.  It extends the capabilities of the aeson-diff packages, and includes template haskell functions for automatically deriving the right instances.
 
 extra-source-files: .travis.yml
@@ -23,7 +28,7 @@ Source-repository head
   location:	https://github.com/kuribas/aeson-diff-generic
 
 Library
-  Ghc-options: -Wall
+  Ghc-options: -Wall -Wcompat
   build-depends: base >= 4.5 && <= 5,
                  aeson >= 1.2.4.0 && < 1.5,
                  aeson-diff >= 1.1.0.0 && < 1.2,
@@ -37,15 +42,15 @@ Library
                  dlist >= 0.6,
                  scientific >= 0.3.4.7 && < 0.4,
                  tagged >=0.8.3 && <0.9,
-                 template-haskell >= 2.7,
+                 template-haskell >= 2.7 && <2.16,
                  text >= 1.1.1.0,
                  th-abstraction >= 0.2.2 && < 0.4,
                  time >= 1.1.1.4,
                  unordered-containers >= 0.2.5.0 && < 0.3,
                  uuid-types >= 1.0.3 && <1.1,
                  vector >= 0.8,
-                 lens >= 4.16 && < 4.18
-                        
+                 lens >= 4.16 && < 4.19
+
 
   if !impl(ghc >= 8.0)
     -- `Data.Semigroup` and `Control.Monad.Fail` and `Control.Monad.IO.Class` are available in base only since GHC 8.0 / base 4.9

--- a/aeson-diff-generic.cabal
+++ b/aeson-diff-generic.cabal
@@ -1,5 +1,5 @@
 Name:		aeson-diff-generic
-Version: 	0.0.3
+Version: 	0.1.0
 Synopsis:	Apply a json-patch to any haskell datatype.
 Category: 	JSON, Web
 Copyright: 	Kristof Bastiaensen (2018)
@@ -14,6 +14,7 @@ Cabal-version:	>=1.8
 Tested-With:    GHC == 7.10.2
                 GHC == 8.0.2
                 GHC == 8.2.2
+                GHC == 8.6.5
 Description:	Apply a json-patch directly to a haskell datatype.  It extends the capabilities of the aeson-diff packages, and includes template haskell functions for automatically deriving the right instances.
 
 extra-source-files: .travis.yml
@@ -27,8 +28,7 @@ Source-repository head
 Library
   Ghc-options: -Wall
   build-depends: base >= 4.5 && <= 5,
-                 base-compat >= 0.9.1 && < 0.10,                 
-                 aeson >= 1.2.4.0 && < 1.3,
+                 aeson >= 1.2.4.0 && < 1.5,
                  aeson-diff >= 1.1.0.0 && < 1.2,
                  bytestring >=0.10 && < 0.11,
                  hashable >= 1.1.2.0,
@@ -36,19 +36,18 @@ Library
                  uuid-types >= 1.0.3 && <1.1,
                  dlist >= 0.6,
                  base >= 4.5 && < 5,
-                 base-compat >= 0.9.1 && < 0.10,
                  containers >= 0.5.8,
                  dlist >= 0.6,
                  scientific >= 0.3.4.7 && < 0.4,
                  tagged >=0.8.3 && <0.9,
                  template-haskell >= 2.7,
                  text >= 1.1.1.0,
-                 th-abstraction >= 0.2.2 && < 0.3,
+                 th-abstraction >= 0.2.2 && < 0.4,
                  time >= 1.1.1.4,
                  unordered-containers >= 0.2.5.0 && < 0.3,
                  uuid-types >= 1.0.3 && <1.1,
                  vector >= 0.8,
-                 lens >= 4.16 && < 4.17
+                 lens >= 4.16 && < 4.18
                         
 
   if !impl(ghc >= 8.0)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-14.5
+packages:
+  - .


### PR DESCRIPTION
- Bump version from 0.0.3 to 0.1.0.
- Update dependency on 'aeson' from <1.3 to <1.5.
- Update dependency on 'th-abstraction from <0.3 to <0.4.
- Update dependency on 'lens' from <4.17 to <4.18.
- Remove dependency on 'base-compat'.

As it's a little unclear why 'base-compat' was necessary, it's estimated
that it no longer is, since it compiles without and we are in the future
now.

The PVP states:

> Note that modifying imports or depending on a newer version of another
> package may cause extra non-orphan instances to be exported and thus
> force a minor version change.

As I am unsure if any of the bumped dependencies cause extra non-orphan
instances, but all of them bump the minor version, a safe choice is to
bump this package's minor version.